### PR TITLE
Add Future page for date-specific tasks

### DIFF
--- a/lib/database/task_dao.dart
+++ b/lib/database/task_dao.dart
@@ -207,4 +207,39 @@ class TaskDao {
         .get();
     return results.map((row) => row.toTask()).toList();
   }
+
+  /// Gets all tasks scheduled on a specific day
+  Future<List<Task>> getTasksByDay(DateTime day) async {
+    final startOfDay = DateTime(day.year, day.month, day.day);
+    final endOfDay = startOfDay.add(const Duration(days: 1));
+
+    final query = _db.select(_db.tasks)
+      ..where(
+        (t) => ((t.startTime.isBiggerOrEqualValue(startOfDay.toIso8601String()) &
+                t.startTime.isSmallerOrEqualValue(endOfDay.toIso8601String())) |
+            (t.dueTime.isBiggerOrEqualValue(startOfDay.toIso8601String()) &
+                t.dueTime.isSmallerOrEqualValue(endOfDay.toIso8601String()))),
+      )
+      ..orderBy([(t) => OrderingTerm.asc(t.startTime)]);
+
+    final results = await query.get();
+    return results.map((row) => row.toTask()).toList();
+  }
+
+  /// Watches tasks scheduled on a specific day
+  Stream<List<Task>> watchTasksByDay(DateTime day) {
+    final startOfDay = DateTime(day.year, day.month, day.day);
+    final endOfDay = startOfDay.add(const Duration(days: 1));
+
+    final query = _db.select(_db.tasks)
+      ..where(
+        (t) => ((t.startTime.isBiggerOrEqualValue(startOfDay.toIso8601String()) &
+                t.startTime.isSmallerOrEqualValue(endOfDay.toIso8601String())) |
+            (t.dueTime.isBiggerOrEqualValue(startOfDay.toIso8601String()) &
+                t.dueTime.isSmallerOrEqualValue(endOfDay.toIso8601String()))),
+      )
+      ..orderBy([(t) => OrderingTerm.asc(t.startTime)]);
+
+    return query.watch().map((rows) => rows.map((row) => row.toTask()).toList());
+  }
 }

--- a/lib/features/future/future_page.dart
+++ b/lib/features/future/future_page.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../providers/database/index.dart';
+import '../../widgets/plan_task_card.dart';
+
+class FuturePage extends ConsumerStatefulWidget {
+  const FuturePage({super.key});
+
+  @override
+  ConsumerState<FuturePage> createState() => _FuturePageState();
+}
+
+class _FuturePageState extends ConsumerState<FuturePage> {
+  DateTime _selectedDate = DateTime.now();
+
+  Future<void> _pickDate() async {
+    final date = await showDatePicker(
+      context: context,
+      initialDate: _selectedDate,
+      firstDate: DateTime(2020),
+      lastDate: DateTime(2100),
+    );
+    if (date != null) {
+      setState(() {
+        _selectedDate = DateTime(date.year, date.month, date.day);
+      });
+    }
+  }
+
+  String _formatDate(DateTime date) {
+    return '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tasksAsync = ref.watch(watchTasksByDayProvider(_selectedDate));
+
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+        title: Text('Future: ${_formatDate(_selectedDate)}'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.calendar_today),
+            onPressed: _pickDate,
+          ),
+        ],
+      ),
+      body: tasksAsync.when(
+        data: (tasks) {
+          if (tasks.isEmpty) {
+            return const Center(child: Text('No tasks for this day.'));
+          }
+          return ListView.builder(
+            padding: const EdgeInsets.all(8),
+            itemCount: tasks.length,
+            itemBuilder: (context, index) {
+              final task = tasks[index];
+              return PlanTaskCard(
+                task: task,
+                formatDate: _formatDate,
+                onEditPressed: () {},
+                onDeletePressed: () {},
+                onSchedulePressed: (date) async {},
+              );
+            },
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, stack) => Center(child: Text('Error: $error')),
+      ),
+    );
+  }
+}

--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -85,6 +85,14 @@ class _HomePageState extends ConsumerState<HomePage> {
                 Routes.navigateToTasks(context);
               },
             ),
+            ListTile(
+              leading: const Icon(Icons.calendar_month),
+              title: const Text('Future'),
+              onTap: () {
+                Navigator.pop(context);
+                Routes.navigateToFuture(context);
+              },
+            ),
           ],
         ),
       ),

--- a/lib/features/index.dart
+++ b/lib/features/index.dart
@@ -2,3 +2,4 @@ export "./home/home_page.dart";
 export "./tasks/tasks_page.dart";
 export "./routines/routines_page.dart";
 export "./sessions/sessions_page.dart";
+export "./future/future_page.dart";

--- a/lib/providers/database/task_provider.dart
+++ b/lib/providers/database/task_provider.dart
@@ -70,3 +70,21 @@ Stream<List<Task>> completedTasksWithTodaysSessions(Ref ref) {
   ref.watch(currentDateProvider);
   return ref.watch(databaseProvider).taskDao.watchCompletedTasksWithTodaysSessions();
 }
+
+/// Provider for tasks by day
+final tasksByDayProvider = FutureProvider.autoDispose.family<List<Task>, DateTime?>(
+  (ref, date) {
+    final db = ref.watch(databaseProvider);
+    final day = date ?? DateTime.now();
+    return db.taskDao.getTasksByDay(day);
+  },
+);
+
+final watchTasksByDayProvider =
+    StreamProvider.autoDispose.family<List<Task>, DateTime?>(
+  (ref, date) {
+    final db = ref.watch(databaseProvider);
+    final day = date ?? DateTime.now();
+    return db.taskDao.watchTasksByDay(day);
+  },
+);

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -8,6 +8,7 @@ class Routes {
   static const String tasks = '/tasks';
   static const String sessions = '/sessions';
   static const String routines = '/routines';
+  static const String future = '/future';
 
   /// Define routes for the application
   static Map<String, WidgetBuilder> getRoutes() {
@@ -16,6 +17,7 @@ class Routes {
       tasks: (context) => const TasksPage(),
       sessions: (context) => const SessionsPage(),
       routines: (context) => const RoutinesPage(),
+      future: (context) => const FuturePage(),
     };
   }
 
@@ -37,5 +39,10 @@ class Routes {
   /// Navigate to the routines page
   static void navigateToRoutines(BuildContext context) {
     Navigator.pushNamed(context, routines);
+  }
+
+  /// Navigate to the future page
+  static void navigateToFuture(BuildContext context) {
+    Navigator.pushNamed(context, future);
   }
 }


### PR DESCRIPTION
## Summary
- allow filtering tasks by date through `getTasksByDay` and `watchTasksByDay`
- expose new providers `tasksByDayProvider` and `watchTasksByDayProvider`
- create `FuturePage` for viewing tasks on a chosen date
- register `/future` route and navigation
- add Future menu item in the drawer
- export `FuturePage`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a1ee82d083239f8a31efc8fbed58