### PR TITLE
Implement swipe actions on home tasks

### DIFF
--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -8,6 +8,7 @@ import 'package:abun/widgets/session_form.dart';
 import 'package:abun/widgets/task_card.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_slidable/flutter_slidable.dart';
 
 class HomePage extends ConsumerStatefulWidget {
   const HomePage({super.key});
@@ -230,28 +231,55 @@ class _HomePageState extends ConsumerState<HomePage> {
               }
             }
 
-            return TaskCard(
-              key: ValueKey(task.id),
-              task: task,
-              isPastDue: isPastDue, // Pass the flag here
-              onStartPressed: task.status != 'completed'
-                  ? () async {
-                final updatedTask = task.copyWith(
-                  status: 'in_progress',
-                  updatedAt: DateTime.now().toIso8601String(),
-                );
-                await ref.read(databaseProvider).taskDao.updateTask(updatedTask);
-              }
-                  : null,
-              onCompletePressed: task.status != 'completed'
-                  ? () async {
-                final updatedTask = task.copyWith(
-                  status: 'completed',
-                  updatedAt: DateTime.now().toIso8601String(),
-                );
-                await ref.read(databaseProvider).taskDao.updateTask(updatedTask);
-              }
-                  : null,
+            return Slidable(
+              key: ValueKey('slidable-${task.id}'),
+              startActionPane: ActionPane(
+                motion: const DrawerMotion(),
+                dismissible: DismissiblePane(onDismissed: () {
+                  _showSessionFormForTask(context, task, complete: true);
+                }),
+                children: [
+                  SlidableAction(
+                    onPressed: (_) =>
+                        _showSessionFormForTask(context, task, complete: false),
+                    backgroundColor:
+                        Theme.of(context).colorScheme.primaryContainer,
+                    foregroundColor:
+                        Theme.of(context).colorScheme.onPrimaryContainer,
+                    icon: Icons.event_note,
+                    label: 'Log',
+                  ),
+                ],
+              ),
+              child: TaskCard(
+                key: ValueKey(task.id),
+                task: task,
+                isPastDue: isPastDue, // Pass the flag here
+                onStartPressed: task.status != 'completed'
+                    ? () async {
+                        final updatedTask = task.copyWith(
+                          status: 'in_progress',
+                          updatedAt: DateTime.now().toIso8601String(),
+                        );
+                        await ref
+                            .read(databaseProvider)
+                            .taskDao
+                            .updateTask(updatedTask);
+                      }
+                    : null,
+                onCompletePressed: task.status != 'completed'
+                    ? () async {
+                        final updatedTask = task.copyWith(
+                          status: 'completed',
+                          updatedAt: DateTime.now().toIso8601String(),
+                        );
+                        await ref
+                            .read(databaseProvider)
+                            .taskDao
+                            .updateTask(updatedTask);
+                      }
+                    : null,
+              ),
             );
           },
         );
@@ -478,6 +506,21 @@ class _HomePageState extends ConsumerState<HomePage> {
           hour.toString(),
           style: const TextStyle(color: Colors.white, fontSize: 12, fontWeight: FontWeight.normal),
         ),
+      ),
+    );
+  }
+
+  void _showSessionFormForTask(BuildContext context, Task task,
+      {required bool complete}) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (context) => SessionForm(
+        task: task,
+        initialCompleteTask: complete,
       ),
     );
   }

--- a/lib/widgets/session_form.dart
+++ b/lib/widgets/session_form.dart
@@ -14,8 +14,9 @@ import 'datetime_helper.dart';
 
 class SessionForm extends ConsumerStatefulWidget {
   final Task? task;
+  final bool initialCompleteTask;
 
-  const SessionForm({super.key, this.task});
+  const SessionForm({super.key, this.task, this.initialCompleteTask = false});
 
   @override
   ConsumerState<SessionForm> createState() => _SessionFormState();
@@ -39,6 +40,7 @@ class _SessionFormState extends ConsumerState<SessionForm> {
   @override
   void initState() {
     super.initState();
+    _completeTask = widget.initialCompleteTask;
     final now = DateTime.now();
     _selectedDate = DateTime(now.year, now.month, now.day);
     _selectedTime = TimeOfDay(

--- a/lib/widgets/task_card.dart
+++ b/lib/widgets/task_card.dart
@@ -246,12 +246,17 @@ class TaskCard extends ConsumerWidget {
     }
   }
 
-  void _showSessionForm(BuildContext context) {
+  void _showSessionForm(BuildContext context, {bool completeTask = false}) {
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
-      shape: const RoundedRectangleBorder(borderRadius: BorderRadius.vertical(top: Radius.circular(16))),
-      builder: (context) => SessionForm(task: task),
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (context) => SessionForm(
+        task: task,
+        initialCompleteTask: completeTask,
+      ),
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   intl: ^0.19.0
   timezone: ^0.9.2
   numberpicker: ^2.1.1
+  flutter_slidable: ^3.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- integrate flutter_slidable for gesture controls
- extend SessionForm to accept initialCompleteTask
- wrap home task cards with Slidable to log sessions or finish tasks via swipe

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6848128c27cc8323baf4be9e2b51545c